### PR TITLE
Multiple users typing

### DIFF
--- a/client/src/ChatRoom.js
+++ b/client/src/ChatRoom.js
@@ -19,7 +19,7 @@ function ChatRoom() {
     messages,
     sendMessage,
     sendUserIsTyping,
-    isTyping,
+    usersCurrentlyTyping,
     sendUserNotTyping,
   } = useChat(roomId);
 
@@ -36,11 +36,14 @@ function ChatRoom() {
   }
 
   // could be const ?
-  let typingNotification = isTyping
-    ? (<div id="msgBubbles" className="received isTypingDiv">
-        <p className="mb-0 px-1">...</p>
-      </div>)
-    : ("");
+  let typingNotification =
+    usersCurrentlyTyping.length !== 0 ? (
+      <div id="msgBubbles" className="received isTypingDiv">
+        <p className="mb-0 px-1">{usersCurrentlyTyping.join(", ")} is typing</p>
+      </div>
+    ) : (
+      ""
+    );
 
   // could be const ?
   let currMsgs = messages.map((m, i) => (
@@ -52,6 +55,8 @@ function ChatRoom() {
       <p className="mb-0 px-1">{m.msg}</p>
     </div>
   ));
+
+  console.log("usersCurrentlyTyping", usersCurrentlyTyping);
 
   return (
     <div className="ChatRoom">

--- a/client/src/ChatRoom.js
+++ b/client/src/ChatRoom.js
@@ -35,6 +35,8 @@ function ChatRoom() {
     sendUserNoLongerTyping(handle);
   }
 
+  // usersTypingWithoutMe = [...usersCurrentlyTyping].filter(handle => handle !== )
+
   // could be const ?
   let typingNotification =
     usersCurrentlyTyping.length !== 0 ? (

--- a/client/src/ChatRoom.js
+++ b/client/src/ChatRoom.js
@@ -20,7 +20,6 @@ function ChatRoom() {
     sendMessage,
     sendUserIsTyping,
     usersCurrentlyTyping,
-    sendUserNoLongerTyping,
   } = useChat(roomId);
 
   function sendMsg(fData) {
@@ -31,14 +30,7 @@ function ChatRoom() {
     sendUserIsTyping(handle);
   }
 
-  function noLongerTyping(handle) {
-    sendUserNoLongerTyping(handle);
-  }
-
-  // usersTypingWithoutMe = [...usersCurrentlyTyping].filter(handle => handle !== )
-
-  // could be const ?
-  let typingNotification =
+  const typingNotification =
     usersCurrentlyTyping.length !== 0 ? (
       <div id="msgBubbles" className="received isTypingDiv">
         <p className="mb-0 px-1">{usersCurrentlyTyping.join(", ")} is typing</p>
@@ -47,8 +39,7 @@ function ChatRoom() {
       ""
     );
 
-  // could be const ?
-  let currMsgs = messages.map((m, i) => (
+  const currMsgs = messages.map((m, i) => (
     <div
       id="msgBubbles"
       className={`${m.sentByMe ? "sent ml-auto" : "received"}`}
@@ -68,11 +59,7 @@ function ChatRoom() {
           {currMsgs}
           {typingNotification}
         </div>
-        <Form
-          sendMsg={sendMsg}
-          notifyTyping={notifyTyping}
-          noLongerTyping={noLongerTyping}
-        />
+        <Form sendMsg={sendMsg} notifyTyping={notifyTyping} />
       </div>
     </div>
   );

--- a/client/src/ChatRoom.js
+++ b/client/src/ChatRoom.js
@@ -20,7 +20,7 @@ function ChatRoom() {
     sendMessage,
     sendUserIsTyping,
     usersCurrentlyTyping,
-    sendUserNotTyping,
+    sendUserNoLongerTyping,
   } = useChat(roomId);
 
   function sendMsg(fData) {
@@ -31,8 +31,8 @@ function ChatRoom() {
     sendUserIsTyping(handle);
   }
 
-  function removeTyping() {
-    sendUserNotTyping();
+  function noLongerTyping(handle) {
+    sendUserNoLongerTyping(handle);
   }
 
   // could be const ?
@@ -56,8 +56,6 @@ function ChatRoom() {
     </div>
   ));
 
-  console.log("usersCurrentlyTyping", usersCurrentlyTyping);
-
   return (
     <div className="ChatRoom">
       <div className="ChatRoom-container">
@@ -71,7 +69,7 @@ function ChatRoom() {
         <Form
           sendMsg={sendMsg}
           notifyTyping={notifyTyping}
-          removeTyping={removeTyping}
+          noLongerTyping={noLongerTyping}
         />
       </div>
     </div>

--- a/client/src/Form.js
+++ b/client/src/Form.js
@@ -16,7 +16,7 @@ import "./Form.css";
  *
  *  App -> ChatRoom -> Form
  */
-function Form({ sendMsg, notifyTyping, removeTyping }) {
+function Form({ sendMsg, notifyTyping, noLongerTyping }) {
   const [formData, setFormData] = useState({ handle: "", msg: "" });
 
   function handleChange(evt) {
@@ -30,7 +30,7 @@ function Form({ sendMsg, notifyTyping, removeTyping }) {
     if (formData.msg.length > 1) {
       notifyTyping(formData.handle);
     } else {
-      removeTyping();
+      noLongerTyping(formData.handle);
     }
   }
 

--- a/client/src/Form.js
+++ b/client/src/Form.js
@@ -16,7 +16,7 @@ import "./Form.css";
  *
  *  App -> ChatRoom -> Form
  */
-function Form({ sendMsg, notifyTyping, noLongerTyping }) {
+function Form({ sendMsg, notifyTyping }) {
   const [formData, setFormData] = useState({ handle: "", msg: "" });
 
   function handleChange(evt) {
@@ -29,8 +29,6 @@ function Form({ sendMsg, notifyTyping, noLongerTyping }) {
     // handles typing notification
     if (formData.msg.length > 1) {
       notifyTyping(formData.handle);
-    } else {
-      noLongerTyping(formData.handle);
     }
   }
 

--- a/client/src/useChat.js
+++ b/client/src/useChat.js
@@ -36,24 +36,6 @@ function useChat(roomName) {
       });
     });
 
-    // this is not being used. need to figure out why
-    socketRef.current.on("userNoLongerTyping", function (handle) {
-      setUsersCurrentlyTyping((usersCurrentlyTyping) => {
-        const indexOfHandleToRemove = usersCurrentlyTyping.indexOf(handle);
-        let newUsersCurrTyping;
-        if (indexOfHandleToRemove >= 0) {
-          newUsersCurrTyping = [
-            ...usersCurrentlyTyping.slice(0, indexOfHandleToRemove),
-            ...usersCurrentlyTyping.slice(
-              indexOfHandleToRemove,
-              indexOfHandleToRemove.length
-            ),
-          ];
-        }
-        return usersCurrentlyTyping;
-      });
-    });
-
     // ends connection
     return () => {
       socketRef.current.disconnect();
@@ -72,16 +54,11 @@ function useChat(roomName) {
     socketRef.current.emit("userIsTyping", handle);
   }
 
-  function sendUserNoLongerTyping(handle) {
-    socketRef.current.emit("userNoLongerTyping", handle);
-  }
-
   return {
     messages,
     sendMessage,
     sendUserIsTyping,
     usersCurrentlyTyping,
-    sendUserNoLongerTyping,
   };
 }
 

--- a/client/src/useChat.js
+++ b/client/src/useChat.js
@@ -9,7 +9,7 @@ const SERVER = "http://localhost:8000";
  */
 function useChat(roomName) {
   const [messages, setMessages] = useState([]);
-  const [isTyping, setIsTyping] = useState(false);
+  const [usersCurrentlyTyping, setUsersCurrentlyTyping] = useState([]);
   const socketRef = useRef();
 
   useEffect(() => {
@@ -24,15 +24,20 @@ function useChat(roomName) {
         sentByMe: message.senderId === socketRef.current.id,
       };
       setMessages((messages) => [...messages, incomingMessage]);
-      setIsTyping(false);
+      // setIsTyping(false); remove the user from the array of current typers
     });
 
     socketRef.current.on("userIsTyping", function (handle) {
-      setIsTyping(true);
+      setUsersCurrentlyTyping((usersCurrentlyTyping) => {
+        if (!usersCurrentlyTyping.includes(handle)) {
+          return [...usersCurrentlyTyping, handle];
+        }
+        return usersCurrentlyTyping;
+      });
     });
 
     socketRef.current.on("userNotTyping", function () {
-      setIsTyping(false);
+      setUsersCurrentlyTyping([]);
     });
 
     // ends connection
@@ -61,7 +66,7 @@ function useChat(roomName) {
     messages,
     sendMessage,
     sendUserIsTyping,
-    isTyping,
+    usersCurrentlyTyping,
     sendUserNotTyping,
   };
 }

--- a/client/src/useChat.js
+++ b/client/src/useChat.js
@@ -24,7 +24,7 @@ function useChat(roomName) {
         sentByMe: message.senderId === socketRef.current.id,
       };
       setMessages((messages) => [...messages, incomingMessage]);
-      // setIsTyping(false); remove the user from the array of current typers
+      setUsersCurrentlyTyping([]);
     });
 
     socketRef.current.on("userIsTyping", function (handle) {
@@ -36,8 +36,22 @@ function useChat(roomName) {
       });
     });
 
-    socketRef.current.on("userNotTyping", function () {
-      setUsersCurrentlyTyping([]);
+    // this is not being used. need to figure out why
+    socketRef.current.on("userNoLongerTyping", function (handle) {
+      setUsersCurrentlyTyping((usersCurrentlyTyping) => {
+        const indexOfHandleToRemove = usersCurrentlyTyping.indexOf(handle);
+        let newUsersCurrTyping;
+        if (indexOfHandleToRemove >= 0) {
+          newUsersCurrTyping = [
+            ...usersCurrentlyTyping.slice(0, indexOfHandleToRemove),
+            ...usersCurrentlyTyping.slice(
+              indexOfHandleToRemove,
+              indexOfHandleToRemove.length
+            ),
+          ];
+        }
+        return usersCurrentlyTyping;
+      });
     });
 
     // ends connection
@@ -58,8 +72,8 @@ function useChat(roomName) {
     socketRef.current.emit("userIsTyping", handle);
   }
 
-  function sendUserNotTyping() {
-    socketRef.current.emit("userNotTyping");
+  function sendUserNoLongerTyping(handle) {
+    socketRef.current.emit("userNoLongerTyping", handle);
   }
 
   return {
@@ -67,7 +81,7 @@ function useChat(roomName) {
     sendMessage,
     sendUserIsTyping,
     usersCurrentlyTyping,
-    sendUserNotTyping,
+    sendUserNoLongerTyping,
   };
 }
 


### PR DESCRIPTION
### Summary
This PR does 3 things:
1. Previously, the typing notification (indicating another user typing) would show up as ellipses, now this shows the handle of who is typing
2. This also now can show multiple users typing at once
3. This PR _removes_ logic for clearing the typing notification- and just clears the notification when the users sends. Not ideal, but [Ticket 9](https://github.com/viveksainanee/dentalchat/issues/9) will still be open to follow up on this.

### Reproduction steps
1. open multiple clients
2. send a chat from one to the other and see typing notification on both clients when both users are typing