### PR TITLE
added localStorage functionality

### DIFF
--- a/client/src/ChatRoom.js
+++ b/client/src/ChatRoom.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import Form from "./Form";
 import "./ChatRoom.css";

--- a/client/src/useChat.js
+++ b/client/src/useChat.js
@@ -14,11 +14,22 @@ function useChat(roomName) {
   const [isTyping, setIsTyping] = useState(false);
   const socketRef = useRef();
 
+  /** function runs only after initial render */
+  useEffect(() => {
+    const msgsInLocalStorage = localStorage.getItem('messages') !== "{}"
+      ? localStorage.getItem('messages')
+      : '';
+
+    if (msgsInLocalStorage && msgsInLocalStorage !== '') {
+      setMessages(JSON.parse(msgsInLocalStorage));
+    }
+  }, []);
+
+
   useEffect(() => {
     socketRef.current = io(SERVER, {
       query: { roomName },
     });
-
 
     /*************************************
      *************************************
@@ -83,10 +94,15 @@ function useChat(roomName) {
       });
     });
 
+    // adds every message and thread to local storage
+    const msgsCopy = JSON.stringify(messages);
+    localStorage.setItem('messages', msgsCopy);
+
     // ends connection
     return () => {
       socketRef.current.disconnect();
     };
+
   }, [roomName, messages]);
   /*************** END useEFFECT **************/
 


### PR DESCRIPTION
### Summary

Now when a user loads the chatroom, the app first looks to local storage for existing messages. 

If none exist, everything proceeds as normal (the chatroom starts with no messages in the window), but if localStorage does have messages - the app loads them into the window.

Every new message gets added to localStorage. Users can hard refresh and still see conversation.

NOTE: On refresh - form is cleared and so handle needs to be reentered (this will be fixed in settings branch).

### Reproduction steps

### Test coverage before

### Test coverage after
